### PR TITLE
Reduce Server implementation complexity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,11 @@ and this project adheres poorly to [Semantic Versioning](https://semver.org/spec
 ## [Unreleased]
 ### Added
 - Swagger intergation. The OpenAPI JSON is automatically generated and served along with Swagger UI when in development mode or explicitly configured.
+- `AuthenticatedApplicationAdapter` for explicitly wrapping an `AuthenticatedApplication`.
 
 ### Changed
 - Refactor `StaticFiles` into an interface and use the value class version as a default implementation.
+- Refactor `Server` to allow its implementations to be defined using only the `ApplicationAdapter` or `AuthenticatedApplicationAdapter`.
 
 ### Removed
 - Deprecated `StaticFiles` getters without the `get` prefix.

--- a/snoozy-core/src/main/java/fi/jubic/snoozy/Server.java
+++ b/snoozy-core/src/main/java/fi/jubic/snoozy/Server.java
@@ -1,16 +1,101 @@
 package fi.jubic.snoozy;
 
 import fi.jubic.snoozy.auth.UserPrincipal;
+import fi.jubic.snoozy.server.ApplicationAdapter;
+import fi.jubic.snoozy.server.AuthFilterAdapter;
+import fi.jubic.snoozy.server.AuthenticatedApplicationAdapter;
 
 public interface Server {
-    void start(
+    /**
+     * Start an {@link Application} in a new thread(s).
+     */
+    default void start(
             Application application,
             ServerConfigurator serverConfigurator
-    );
+    ) {
+        start(application, serverConfigurator.getServerConfiguration());
+    }
 
-    <P extends UserPrincipal> void start(
+    /**
+     * Start an {@link Application} in a new thread(s).
+     */
+    default void start(
+            Application application,
+            ServerConfiguration serverConfiguration
+    ) {
+        ApplicationAdapter applicationAdapter = new ApplicationAdapter(
+                application,
+                serverConfiguration
+        );
+        start(
+                applicationAdapter,
+                serverConfiguration
+        );
+        applicationAdapter.logStartup();
+    }
+
+    /**
+     * Start an {@link AuthenticatedApplication} in a new thread(s).
+     */
+    default <P extends UserPrincipal> void start(
             AuthenticatedApplication<P> application,
             ServerConfigurator serverConfigurator
+    ) {
+        start(application, serverConfigurator.getServerConfiguration());
+    }
+
+    /**
+     * Start an {@link AuthenticatedApplication} in a new thread(s).
+     */
+    default <P extends UserPrincipal> void start(
+            AuthenticatedApplication<P> application,
+            ServerConfiguration serverConfiguration
+    ) {
+        AuthenticatedApplicationAdapter<P> applicationAdapter
+                = new AuthenticatedApplicationAdapter<>(application, serverConfiguration);
+        start(
+                applicationAdapter,
+                serverConfiguration
+        );
+        applicationAdapter.logStartup();
+    }
+
+    /**
+     * <p>
+     *     Start an {@link ApplicationAdapter} in a new thread(s). The main control flow can reach
+     *     its end after calling this function without stopping the application.
+     * </p>
+     *
+     * <p>
+     *     A {@link Server} implementation should not override the non-adapter methods to avoid
+     *     picking up unnecessary housekeeping responsibilities like post-start logging.
+     * </p>
+     */
+    void start(
+            ApplicationAdapter applicationAdapter,
+            ServerConfiguration serverConfiguration
+    );
+
+    /**
+     * <p>
+     *     Start an {@link AuthenticatedApplicationAdapter} in a new thread(s). The main control
+     *     flow can reach its end after calling this function without stopping the application.
+     * </p>
+     *
+     * <p>
+     *     A {@link Server} implementation should not override the non-adapter methods to avoid
+     *     picking up unnecessary housekeeping responsibilities like post-start logging.
+     * </p>
+     *
+     * <p>
+     *     The {@link Server} implementation needs to call
+     *     {@link AuthenticatedApplicationAdapter#setAuthFilterAdapter(AuthFilterAdapter)} to when
+     *     starting the application to setup server specific auth support.
+     * </p>
+     */
+    <P extends UserPrincipal> void start(
+            AuthenticatedApplicationAdapter<P> applicationAdapter,
+            ServerConfiguration serverConfiguration
     );
 
     void stop();

--- a/snoozy-core/src/main/java/fi/jubic/snoozy/server/ApplicationAdapter.java
+++ b/snoozy-core/src/main/java/fi/jubic/snoozy/server/ApplicationAdapter.java
@@ -1,9 +1,7 @@
 package fi.jubic.snoozy.server;
 
 import fi.jubic.snoozy.Application;
-import fi.jubic.snoozy.AuthenticatedApplication;
 import fi.jubic.snoozy.ServerConfiguration;
-import fi.jubic.snoozy.auth.UserPrincipal;
 import fi.jubic.snoozy.staticfiles.StaticFiles;
 import fi.jubic.snoozy.swagger.SwaggerResource;
 import fi.jubic.snoozy.swagger.SwaggerStaticFiles;
@@ -47,26 +45,6 @@ public class ApplicationAdapter extends javax.ws.rs.core.Application {
         this.filters.add(application.getLoggingFilter());
     }
 
-    /**
-     * Wrap an authenticated Application injecting the following built-ins.
-     *
-     * <ul>
-     *     <li>Request logging</li>
-     *     <li>Auth filter</li>
-     * </ul>
-     *
-     * @param <P> User principal type
-     */
-    public <P extends UserPrincipal> ApplicationAdapter(
-            AuthenticatedApplication<P> application,
-            ServerConfiguration serverConfiguration,
-            AuthFilterAdapter<P> authFilterAdapter
-    ) {
-        this(application, serverConfiguration);
-
-        filters.add(authFilterAdapter);
-    }
-
     public Class<?> getApplicationClass() {
         return application.getClass();
     }
@@ -103,7 +81,7 @@ public class ApplicationAdapter extends javax.ws.rs.core.Application {
     }
 
     /**
-     * Performs startup logging. Server implementation should always call this method.
+     * Performs startup logging.
      */
     public void logStartup() {
         application.getBanner().ifPresent(banner -> {

--- a/snoozy-core/src/main/java/fi/jubic/snoozy/server/AuthenticatedApplicationAdapter.java
+++ b/snoozy-core/src/main/java/fi/jubic/snoozy/server/AuthenticatedApplicationAdapter.java
@@ -1,0 +1,50 @@
+package fi.jubic.snoozy.server;
+
+import fi.jubic.snoozy.AuthenticatedApplication;
+import fi.jubic.snoozy.ServerConfiguration;
+import fi.jubic.snoozy.auth.Authentication;
+import fi.jubic.snoozy.auth.UserPrincipal;
+
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class AuthenticatedApplicationAdapter<P extends UserPrincipal> extends ApplicationAdapter {
+    private final AuthenticatedApplication<P> authenticatedApplication;
+    private AuthFilterAdapter<P> authFilterAdapter;
+
+    /**
+     * Wrap an authenticated Application injecting the following built-ins.
+     *
+     * <ul>
+     *     <li>Request logging</li>
+     *     <li>Auth filter</li>
+     * </ul>
+     */
+    public AuthenticatedApplicationAdapter(
+            AuthenticatedApplication<P> application,
+            ServerConfiguration serverConfiguration
+    ) {
+        super(application, serverConfiguration);
+        this.authenticatedApplication = application;
+    }
+
+    public void setAuthFilterAdapter(AuthFilterAdapter<P> authFilterAdapter) {
+        this.authFilterAdapter = authFilterAdapter;
+    }
+
+    public Authentication<P> getAuthentication() {
+        return authenticatedApplication.getAuthentication();
+    }
+
+    @Override
+    public Set<Object> getSingletons() {
+        return Stream
+                .concat(
+                        super.getSingletons().stream(),
+                        Stream.of(Objects.requireNonNull(authFilterAdapter))
+                )
+                .collect(Collectors.toSet());
+    }
+}


### PR DESCRIPTION
* Add `AuthenticatedApplicationAdapter` to allow using different allow `Server` to be implemented without having to construct the adapter manually.

* Add default implementations to `Server` for starting `Applications` and `AuthenticatedApplications`.

* Simplify `UndertowServer` implementation.